### PR TITLE
Support x86 build artefacts

### DIFF
--- a/.github/workflows/build-mesa.yml
+++ b/.github/workflows/build-mesa.yml
@@ -5,13 +5,12 @@ on:
   push:
     branches:
       - main
-
 jobs:
   build:
     runs-on: windows-2022
     strategy:
       matrix:
-        arch: [x64, arm64]
+        arch: [x64, arm64, x86]
 
     outputs:
       MESA_VERSION: ${{ steps.build.outputs.MESA_VERSION }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Automatic build of [mesa][] opengl & vulkan implementations for 64-bit Windows.
+Automatic build of [mesa][] opengl & vulkan implementations for Windows (x64, arm64, x86).
 
 Builds are linked statically to their dependencies, just place necessary dll file next to your exe and it will use it.
 

--- a/build.cmd
+++ b/build.cmd
@@ -10,6 +10,8 @@ if "%1" equ "x64" (
   set MESA_ARCH=x64
 ) else if "%1" equ "arm64" (
   set MESA_ARCH=arm64
+) else if "%1" equ "x86" (
+  set MESA_ARCH=x86
 ) else if "%1" neq "" (
   echo Unknown "%1" architecture!
   exit /b 1
@@ -17,6 +19,8 @@ if "%1" equ "x64" (
   set MESA_ARCH=x64
 ) else if "%PROCESSOR_ARCHITECTURE%" equ "ARM64" (
   set MESA_ARCH=arm64
+) else if "%PROCESSOR_ARCHITECTURE%" equ "x86" (
+  set MESA_ARCH=x86
 ) else (
   echo Unknown host architecture!
   exit /b 1
@@ -30,18 +34,27 @@ if "%MESA_ARCH%" equ "x64" (
   set TARGET_ARCH=arm64
   set LLVM_TARGETS_TO_BUILD=AArch64
   set TARGET_ARCH_NAME=aarch64
+) else if "%MESA_ARCH%" equ "x86" (
+  set TARGET_ARCH=x86
+  set LLVM_TARGETS_TO_BUILD=X86
+  set TARGET_ARCH_NAME=x86
 )
 
 if "%PROCESSOR_ARCHITECTURE%" equ "AMD64" (
   set HOST_ARCH=amd64
 ) else if "%PROCESSOR_ARCHITECTURE%" equ "ARM64" (
   set HOST_ARCH=arm64
+) else if "%PROCESSOR_ARCHITECTURE%" equ "x86" (
+  set HOST_ARCH=x86
 )
 
 if "!TARGET_ARCH!" neq "!HOST_ARCH!" (
   set LLVM_CROSS_CMAKE_FLAGS=-D CMAKE_SYSTEM_NAME=Windows -D LLVM_NATIVE_TOOL_DIR="%CD%\llvm.build-native\bin"
   set MESON_CROSS=--cross-file "%CD%\meson-%MESA_ARCH%.txt"
 ) else if "%MESA_ARCH%" equ "arm64" (
+  set LLVM_CROSS_CMAKE_FLAGS=
+  set MESON_CROSS=
+) else if "%MESA_ARCH%" equ "x86" (
   set LLVM_CROSS_CMAKE_FLAGS=
   set MESON_CROSS=
 )
@@ -114,6 +127,8 @@ where /q ninja.exe || (
     curl -LOsf https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip || exit /b 1
   ) else if "%PROCESSOR_ARCHITECTURE%" equ "ARM64" (
     curl -Lsf -o ninja-win.zip https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-winarm64.zip || exit /b 1
+  ) else if "%PROCESSOR_ARCHITECTURE%" equ "x86" (
+    curl -LOsf https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip || exit /b 1
   )
   %SZIP% x -bb0 -y ninja-win.zip 1>nul 2>nul || exit /b 1
   del ninja-win.zip 1>nul 2>nul

--- a/meson-x86.txt
+++ b/meson-x86.txt
@@ -1,0 +1,12 @@
+[binaries]
+c = 'cl.exe'
+cpp = 'cl.exe'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true

--- a/meson.llvm.build
+++ b/meson.llvm.build
@@ -20,6 +20,10 @@ if host_machine.cpu_family() == 'aarch64'
   folder = '../../../llvm-arm64'
   deps += ['LLVMAArch64AsmParser', 'LLVMAArch64CodeGen', 'LLVMAArch64Desc',
            'LLVMAArch64Disassembler', 'LLVMAArch64Info', 'LLVMAArch64Utils']
+elif host_machine.cpu_family() == 'x86'
+  folder = '../../../llvm-x86'
+  deps += ['LLVMX86AsmParser', 'LLVMX86CodeGen', 'LLVMX86Desc', 'LLVMX86Disassembler',
+           'LLVMX86Info', 'LLVMX86TargetMCA']
 else
   folder = '../../../llvm-x64'
   deps += ['LLVMX86AsmParser', 'LLVMX86CodeGen', 'LLVMX86Desc', 'LLVMX86Disassembler',


### PR DESCRIPTION
Per issue #9 
This PR introduces build artefacts for win32 (x86)

I've only tested against opengl32.dll and it seems good as far back as Windows 8.1
It doesn't particularly like Windows 7 or earlier as is