### PR TITLE
Fix the incorrect path in the Vulkan ICD files

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -263,7 +263,7 @@ meson.exe setup ^
   -Dgles2=enabled ^
   %MESON_CROSS% || exit /b 1
 ninja.exe -C mesa-build-%MESA_ARCH% install || exit /b 1
-python.exe mesa-%MESA_VERSION%\src\vulkan\util\vk_icd_gen.py --api-version 1.4 --xml mesa-%MESA_VERSION%\src\vulkan\registry\vk.xml --icd-lib-path . --icd-filename vulkan_lvp.dll --out mesa-llvmpipe-%MESA_ARCH%\bin\lvp_icd.%TARGET_ARCH_NAME%.json || exit /b 1
+python.exe mesa-%MESA_VERSION%\src\vulkan\util\vk_icd_gen.py --api-version 1.4 --xml mesa-%MESA_VERSION%\src\vulkan\registry\vk.xml --icd-lib-path . --icd-filename vulkan_lvp.dll --use-backslash --out mesa-llvmpipe-%MESA_ARCH%\bin\lvp_icd.%TARGET_ARCH_NAME%.json || exit /b 1
 
 rem *** d3d12, dzn ***
 
@@ -289,7 +289,7 @@ meson.exe setup ^
   -Dgles2=enabled ^
   %MESON_CROSS% || exit /b 1
 ninja.exe -C mesa-build-%MESA_ARCH% install || exit /b 1
-python.exe mesa-%MESA_VERSION%\src\vulkan\util\vk_icd_gen.py --api-version 1.1 --xml mesa-%MESA_VERSION%\src\vulkan\registry\vk.xml --icd-lib-path . --icd-filename vulkan_dzn.dll --out mesa-d3d12-%MESA_ARCH%\bin\dzn_icd.%TARGET_ARCH_NAME%.json || exit /b 1
+python.exe mesa-%MESA_VERSION%\src\vulkan\util\vk_icd_gen.py --api-version 1.1 --xml mesa-%MESA_VERSION%\src\vulkan\registry\vk.xml --icd-lib-path . --icd-filename vulkan_dzn.dll --use-backslash --out mesa-d3d12-%MESA_ARCH%\bin\dzn_icd.%TARGET_ARCH_NAME%.json || exit /b 1
 
 rem *** zink ***
 


### PR DESCRIPTION
The contents of the Vulkan driver's ICD file currently built by this project look something like this:

```
{
    "ICD": {
        "api_version": "1.4.335",
        "library_path": "./vulkan_lvp.dll"
    },
    "file_format_version": "1.0.1"
}
```

The use of "/" as a path separator in `library_path` violates the requirements of the Windows LoadLibrary function, causing it to search for the DLL based on the user's working directory instead of the relative path of the ICD file. This can cause users to be unable to load these Vulkan drivers in many cases.

This problem can be reproduced in this simple way:

```
PS C:\dir1> ls C:\dir2

    Directory: C:\dir2

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            2026/4/4    15:00            141 lvp_icd.x86_64.json
-a---            2026/4/4    15:00       53931008 vulkan_lvp.dll

PS C:\dir1> $env:VK_ICD_FILENAMES='C:\dir2\lvp_icd.x86_64.json'
PS C:\dir1> vulkaninfo --summary
ERROR at C:\SDKBuild\build-X64-1.4.321.0\Vulkan-Tools\vulkaninfo\vulkaninfo.h:247:vkEnumerateInstanceExtensionProperties failed with ERROR_OUT_OF_HOST_MEMORY
```

This PR solved the problem by replacing the path separator with `\`.